### PR TITLE
Update huggingface-cli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you're planning on using any API-based models, make sure you define your rele
 The images and text are stored on the HuggingFace hub, as a .zip. You may download it directly from there, using `huggingface-cli` (recommended):
 
 ```bash
-huggingface-cli download answerdotai/ReadBench readbench.zip --type dataset
+huggingface-cli download answerdotai/ReadBench readbench.zip --dataset-type dataset
 ```
 
 Alternatively, if you are unable to use `huggingface-cli`, you may use the direct download URL, as provided by HuggingFace:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you're planning on using any API-based models, make sure you define your rele
 The images and text are stored on the HuggingFace hub, as a .zip. You may download it directly from there, using `huggingface-cli` (recommended):
 
 ```bash
-huggingface-cli download answerdotai/ReadBench readbench.zip --dataset-type dataset
+huggingface-cli download answerdotai/ReadBench readbench.zip --repo-type dataset
 ```
 
 Alternatively, if you are unable to use `huggingface-cli`, you may use the direct download URL, as provided by HuggingFace:


### PR DESCRIPTION
The `type` parameter in `huggingface-cli download` doesn't exist (anymore?).

The error when running the original command:
```
(readbench)% huggingface-cli download answerdotai/ReadBench readbench.zip --type dataset

usage: huggingface-cli <command> [<args>]
huggingface-cli: error: unrecognized arguments: --type dataset...
```
Checking the `huggingface-cli` version:
```
(readbench) % huggingface-cli version                                                    
huggingface_hub version: 0.32.4
```
That's the latest version (20250609): 
<img width="1342" alt="image" src="https://github.com/user-attachments/assets/f615cb82-e4ae-4fdb-81bd-86f9f6d0c090" />

The correct parameter is `repo-type`, `huggingface-cli download --help` outputs:
<img width="1107" alt="image" src="https://github.com/user-attachments/assets/3bbc0e30-9b34-40da-a7d4-02c05a40b665" />

Btw, this command won't still work, because the dataset is not yet on HF (20250609, 8:36pm CET):
<img width="1094" alt="image" src="https://github.com/user-attachments/assets/361e5702-b997-4b4d-a551-6e8e8d9b3fc3" />

The error when running the new command is:
```
Entry Not Found for url: https://huggingface.co/datasets/answerdotai/ReadBench/resolve/main/readbench.zip.
```
